### PR TITLE
Update workflows to use artifact actions v4 and replace the archived workflow …

### DIFF
--- a/.github/workflows/inspec-check.yml
+++ b/.github/workflows/inspec-check.yml
@@ -10,7 +10,7 @@ jobs:
       CHEF_LICENSE: accept-silent
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get InSpec Version
         run: inspec -v
       - name: Vendor the profile

--- a/.github/workflows/inspec-check.yml
+++ b/.github/workflows/inspec-check.yml
@@ -10,7 +10,7 @@ jobs:
       CHEF_LICENSE: accept-silent
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
       - name: Get InSpec Version
         run: inspec -v
       - name: Vendor the profile

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -21,15 +21,15 @@ jobs:
       - name: Add jq for output formatting
         run: brew install jq
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
       - name: Setup caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -55,7 +55,7 @@ jobs:
           bundle exec inspec_tools compliance -j test/cookbooks/${{ matrix.suite }}/windows-10-ltsc-${{ matrix.suite }}-results.json -f ${{ matrix.suite }}.threshold.yml
           bundle exec inspec_tools compliance -j test/cookbooks/${{ matrix.suite }}/windows-10-${{ matrix.suite }}-results.json -f ${{ matrix.suite }}.threshold.yml
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: test/cookbooks/${{ matrix.suite }}/*-results.json
           if-no-files-found: error

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Add jq for output formatting
         run: brew install jq
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/verify-vagrant.yml
+++ b/.github/workflows/verify-vagrant.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Save Test Result JSON
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.suite }}-results
           path: test/cookbooks/${{ matrix.suite }}/*-results.json
           if-no-files-found: error
 


### PR DESCRIPTION
…actions/setup-ruby@v1 with ruby/setup-ruby@v1

Changes made

- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025.
- Also actions/setup-ruby is archived and has been recommended instead to use ruby/setup-ruby
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)